### PR TITLE
Use KeyPair instead of CellId.

### DIFF
--- a/srither-solver/src/model/mod.rs
+++ b/srither-solver/src/model/mod.rs
@@ -9,7 +9,7 @@
 use {Error, SolverResult};
 
 pub use self::connect_map::ConnectMap;
-pub use self::side_map::SideMap;
+pub use self::side_map::{KeyPair, SideMap};
 pub use self::theorem::Theorem;
 pub use self::theorem_pool::TheoremPool;
 

--- a/srither-solver/src/model/theorem_pool.rs
+++ b/srither-solver/src/model/theorem_pool.rs
@@ -13,13 +13,13 @@ use srither_core::geom::{CellId, Geom, Move};
 use srither_core::puzzle::{Edge, Puzzle};
 
 use {Error, SolverResult};
-use model::{SideMap, State};
+use model::{KeyPair, SideMap, State};
 use model::pattern::EdgePattern;
 use model::theorem::{Theorem, PartialTheorem, MatchResult};
 
 #[derive(Clone, Debug)]
 struct IndexByEdge {
-    points: (CellId, CellId),
+    points: (KeyPair, KeyPair),
     expect_line: Vec<usize>,
     expect_cross: Vec<usize>,
 }
@@ -88,7 +88,7 @@ impl TheoremPool {
         let edges = map.into_iter()
                        .map(|(points, ex)| {
                            IndexByEdge {
-                               points: points,
+                               points: (points.0.into(), points.1.into()),
                                expect_line: ex.0,
                                expect_cross: ex.1,
                            }


### PR DESCRIPTION
Reduce conversion from CellId to KeyPair (multiplication and addition).
